### PR TITLE
Allow function parameters to be unused without provoking unused-var warning

### DIFF
--- a/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -345,6 +345,12 @@ class Generic_Sniffs_CodeAnalysis_VariableAnalysisSniff implements PHP_CodeSniff
     public $allowUnusedCaughtExceptions = false;
 
     /**
+     *  Allow function parameters to be unused without provoking unused-var warning.
+     *  Set generic.codeanalysis.variableanalysis.allowUnusedFunctionParameters to a true value.
+     */
+    public $allowUnusedFunctionParameters = false;
+
+    /**
      *  A list of names of placeholder variables that you want to ignore from
      *  unused variable warnings, ie things like $junk.
      */
@@ -1451,6 +1457,9 @@ class Generic_Sniffs_CodeAnalysis_VariableAnalysisSniff implements PHP_CodeSniff
         }
         foreach ($scopeInfo->variables as $varInfo) {
             if ($varInfo->ignoreUnused || isset($varInfo->firstRead)) {
+                continue;
+            }
+            if ($this->allowUnusedFunctionParameters && $varInfo->scopeType == 'param') {
                 continue;
             }
             if ($varInfo->passByReference && isset($varInfo->firstInitialized)) {


### PR DESCRIPTION
I have added an option for allowing function parameters to be unused without provoking unused-var warning.

When implementing callbacks, Drupal hooks, etc. it is common to define functions with a parameter list but not actually use all of the parameters. Gettings warnings for these can be quite annoying.

This option gives you the ability to disable the the check for unused function parameters.
