### PR TITLE
Corrects Trait Scoping Issue.

### DIFF
--- a/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
+++ b/Sniffs/CodeAnalysis/VariableAnalysisSniff.php
@@ -577,7 +577,7 @@ class Generic_Sniffs_CodeAnalysis_VariableAnalysisSniff implements PHP_CodeSniff
                 if (($scopeCode === T_FUNCTION) || ($scopeCode === T_CLOSURE)) {
                     return $scopePtr;
                 }
-                if (($scopeCode === T_CLASS) || ($scopeCode === T_INTERFACE)) {
+                if (($scopeCode === T_CLASS) || ($scopeCode === T_INTERFACE) || ($scopeCode === T_TRAIT)) {
                     $in_class = true;
                 }
             }


### PR DESCRIPTION
The code was not Trait aware.  The following code would complain that $userRoleId was undefined. I've simply made it switch traits into class scoping mode.

``` php
<?php

namespace Traits;

trait UserRoleIdAwareTrait {

    /** a user id to tie to an object */
    protected $userRoleId;

    //...

}
```
